### PR TITLE
Updated deprecated code for PHP 8

### DIFF
--- a/src/Facebook/Authentication/OAuth2Client.php
+++ b/src/Facebook/Authentication/OAuth2Client.php
@@ -143,7 +143,7 @@ class OAuth2Client
             'scope' => implode(',', $scope)
         ];
 
-        return static::BASE_AUTHORIZATION_URL . '/' . $this->graphVersion . '/dialog/oauth?' . http_build_query($params, null, $separator);
+        return static::BASE_AUTHORIZATION_URL . '/' . $this->graphVersion . '/dialog/oauth?' . http_build_query($params, '', $separator);
     }
 
     /**

--- a/src/Facebook/FacebookApp.php
+++ b/src/Facebook/FacebookApp.php
@@ -107,4 +107,14 @@ class FacebookApp implements \Serializable
 
         $this->__construct($id, $secret);
     }
+
+    public function __serialize()
+    {
+        return $this->serialize();
+    }
+
+    public function __unserialize($serialized)
+    {
+        $this->unserialize($serialized);
+    }
 }


### PR DESCRIPTION
- Pass empty string instead of null to http_build_query
- Add __unserialize and __serialize to FacebookApp